### PR TITLE
fix: close critical auth and payment security gaps found in audit

### DIFF
--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -44,25 +44,8 @@ export default function Login() {
   };
 
   const handleGoogleLogin = () => {
-    const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
-    if (!clientId) {
-      toast.error("Google OAuth is not configured");
-      return;
-    }
-
-    const redirectUri = `${window.location.origin}/api/auth/google/callback`;
-    const scope = "openid email profile";
-    const responseType = "code";
-
-    const params = new URLSearchParams({
-      client_id: clientId,
-      redirect_uri: redirectUri,
-      response_type: responseType,
-      scope: scope,
-      prompt: "consent",
-    });
-
-    window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+    // Server issues the OAuth URL with a CSRF state token bound to a short-lived cookie
+    window.location.href = "/api/auth/google/login";
   };
 
 

--- a/server/_core/secrets.ts
+++ b/server/_core/secrets.ts
@@ -19,9 +19,10 @@ export class SecretsManager {
     private static getMasterKey(): Buffer {
         const key = process.env.INTEGRATIONS_MASTER_KEY;
         if (!key) {
-            // Fallback for development only - in production this MUST be set
-            if (process.env.NODE_ENV === 'production') {
-                throw new Error("CRITICAL: INTEGRATIONS_MASTER_KEY not set in production");
+            // Fallback for local development only - every other environment (production,
+            // staging, etc.) MUST set INTEGRATIONS_MASTER_KEY explicitly.
+            if (process.env.NODE_ENV !== 'development') {
+                throw new Error("CRITICAL: INTEGRATIONS_MASTER_KEY not set");
             }
 
             // Warn once in development

--- a/server/domains/auth/adminAuth.ts
+++ b/server/domains/auth/adminAuth.ts
@@ -149,7 +149,9 @@ export async function authenticateSession(db?: Awaited<ReturnType<typeof getDb>>
   req: Request
 ): Promise<{ success: boolean; user?: any; error?: string }> {
   try {
-    if (process.env.OFFLINE_MODE === "1") {
+    // Offline-mode auth bypass is strictly a local-development convenience —
+    // never honor it outside NODE_ENV=development, even if the env var leaks into another environment.
+    if (process.env.OFFLINE_MODE === "1" && process.env.NODE_ENV === "development") {
       return { success: true, user: { id: 999999, email: "dev@local.host", role: "admin", name: "Dev User" } };
     }
 
@@ -190,6 +192,26 @@ export async function authenticateSession(db?: Awaited<ReturnType<typeof getDb>>
     console.error("[Auth] Error authenticating request:", error);
     return { success: false, error: "Invalid session" };
   }
+}
+
+/**
+ * Whether an admin account already exists.
+ * Used to gate the unauthenticated first-run setup endpoint so it can
+ * only ever bootstrap the very first admin (and never reset an existing one).
+ */
+export async function hasAnyAdminUser(): Promise<boolean> {
+  const db = await getDb();
+  if (!db) {
+    // Fail closed: if we can't verify, don't allow setup to proceed.
+    return true;
+  }
+
+  const existing = await db
+    .select({ id: adminCredentials.id })
+    .from(adminCredentials)
+    .limit(1);
+
+  return existing.length > 0;
 }
 
 /**

--- a/server/domains/auth/adminAuthRoutes.ts
+++ b/server/domains/auth/adminAuthRoutes.ts
@@ -19,6 +19,7 @@ import {
   verifyAdminPassword,
   createAdminSessionToken,
   createAdminUser,
+  hasAnyAdminUser,
 } from "./adminAuth";
 import { COOKIE_NAME } from "@shared/const";
 import { getSessionCookieOptions } from "./cookies";
@@ -66,16 +67,21 @@ export function registerAdminAuthRoutes(app: express.Application) {
     res.json({ success: true, message: "Logged out successfully" });
   });
 
-  // Admin setup endpoint (create first admin - should be protected in production)
+  // Admin setup endpoint - bootstraps the FIRST admin account only.
+  // Once any admin exists, this always rejects so it can't be used to create
+  // additional admins or overwrite an existing admin's password.
   app.post("/api/admin/setup", async (req: Request, res: Response) => {
     try {
+      if (await hasAnyAdminUser()) {
+        return res.status(403).json({ error: "Setup already completed" });
+      }
+
       const { email, password, name } = req.body;
 
       if (!email || !password) {
         return res.status(400).json({ error: "Email and password required" });
       }
 
-      // In production, you might want to check for a setup token or disable this after first admin
       const result = await createAdminUser(email, password, name);
 
       if (!result.success) {

--- a/server/domains/auth/googleAuth.ts
+++ b/server/domains/auth/googleAuth.ts
@@ -5,6 +5,17 @@ import { COOKIE_NAME, ONE_YEAR_MS } from "@shared/const";
 import { getSessionCookieOptions } from "./cookies";
 import { SignJWT } from "jose";
 import { ENV } from "../../_core/env";
+import crypto from "crypto";
+
+const OAUTH_STATE_COOKIE = "oauth_state";
+const OAUTH_STATE_MAX_AGE_MS = 10 * 60 * 1000; // 10 minutes
+
+function safeStateMatch(received: string | undefined, expected: string | undefined): boolean {
+  if (!received || !expected || received.length !== expected.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(Buffer.from(received), Buffer.from(expected));
+}
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || "";
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || "";
@@ -22,13 +33,30 @@ const oauth2Client = new OAuth2Client(
 );
 
 export function registerGoogleAuthRoutes(app: Express) {
+  // Start the Google OAuth flow: issue a random CSRF state, store it in a
+  // short-lived httpOnly cookie, and redirect to Google with that state.
+  app.get("/api/auth/google/login", (req: Request, res: Response) => {
+    const state = crypto.randomBytes(32).toString("hex");
+    const cookieOptions = getSessionCookieOptions(req);
+    res.cookie(OAUTH_STATE_COOKIE, state, { ...cookieOptions, maxAge: OAUTH_STATE_MAX_AGE_MS });
+
+    res.redirect(302, getGoogleAuthUrl(state));
+  });
+
   // Google callback endpoint
   app.get("/api/auth/google/callback", async (req: Request, res: Response) => {
     try {
-      const { code } = req.query;
+      const { code, state } = req.query;
 
       if (!code || typeof code !== "string") {
         return res.status(400).json({ error: "Authorization code is required" });
+      }
+
+      const expectedState = req.cookies?.[OAUTH_STATE_COOKIE];
+      res.clearCookie(OAUTH_STATE_COOKIE, getSessionCookieOptions(req));
+
+      if (typeof state !== "string" || !safeStateMatch(state, expectedState)) {
+        return res.status(400).json({ error: "Invalid or expired OAuth state" });
       }
 
       // Exchange authorization code for tokens
@@ -104,7 +132,7 @@ export function registerGoogleAuthRoutes(app: Express) {
   });
 }
 
-export function getGoogleAuthUrl(): string {
+export function getGoogleAuthUrl(state: string): string {
   const scopes = [
     "https://www.googleapis.com/auth/userinfo.email",
     "https://www.googleapis.com/auth/userinfo.profile",
@@ -114,6 +142,7 @@ export function getGoogleAuthUrl(): string {
     access_type: "offline",
     scope: scopes,
     prompt: "consent",
+    state,
   });
 
   return url;

--- a/server/routes/payments.ts
+++ b/server/routes/payments.ts
@@ -17,9 +17,13 @@
 import express from "express";
 import Stripe from "stripe";
 import { ENV } from "../_core/env";
-import * as db from "../db";
 import { handleStripeWebhook } from "@/server/domains/commerce/payments";
 import { asyncHandler } from "../_core/errors";
+import {
+  verifyPayPalWebhookSignature,
+  handlePayPalWebhook,
+  getPayPalWebhookId,
+} from "../_core/paypalHandler";
 
 const router = express.Router();
 
@@ -69,30 +73,30 @@ router.post(
   }
 );
 
-// PayPal webhook endpoint
+// PayPal webhook endpoint (signature-verified before any state change is applied)
 router.post("/webhook/paypal", express.json(), asyncHandler(async (req: express.Request, res: express.Response) => {
-  const { event_type, resource } = req.body;
-
-  if (event_type === "PAYMENT.CAPTURE.COMPLETED") {
-    const customId = resource?.custom_id;
-    if (!customId || !customId.startsWith("purchase_")) {
-      console.warn("PayPal webhook: Invalid or missing custom_id");
-      return res.json({ processed: false });
-    }
-
-    const purchaseId = parseInt(customId.replace("purchase_", ""));
-    const transactionId = resource?.id;
-
-    if (!isNaN(purchaseId) && transactionId) {
-      await db.updatePurchase(purchaseId, {
-        status: "completed",
-        transactionId,
-      });
-      console.log(`PayPal payment completed for purchase ${purchaseId}`);
-    }
+  let webhookId: string;
+  try {
+    webhookId = getPayPalWebhookId();
+  } catch (error) {
+    console.error("PayPal webhook: PAYPAL_WEBHOOK_ID not configured", error);
+    return res.status(500).json({ error: "PayPal webhook not configured" });
   }
 
-  res.json({ processed: true });
+  const isValid = await verifyPayPalWebhookSignature(req, webhookId);
+  if (!isValid) {
+    console.warn("PayPal webhook: signature verification failed");
+    return res.status(400).json({ error: "Invalid webhook signature" });
+  }
+
+  try {
+    await handlePayPalWebhook(req.body, req);
+    res.json({ received: true });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error("Error handling PayPal webhook:", message);
+    res.status(500).json({ error: "Webhook processing failed" });
+  }
 }));
 
 export function registerPaymentRoutes(app: express.Application) {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "outputDirectory": "dist/public",
+  "rewrites": [
+    { "source": "/((?!api/).*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary

Following a full codebase audit, this PR fixes the critical/high application-level security issues that were verified by reading the code (separate from the secrets-rotation work, which needs to happen outside of code — see note below).

- **Unauthenticated admin account creation** — `POST /api/admin/setup` had no auth check (only rate limiting) and would silently overwrite an existing admin's password hash if the email matched. It's now gated to first-run bootstrap only: once any admin exists, it always returns 403.
- **PayPal webhook accepted unsigned requests** — the route reimplemented a naive, unverified handler that trusted `event_type`/`resource.custom_id` from the raw POST body to mark purchases `"completed"`. A fully-built signature-verification + event-handler implementation already existed in `server/_core/paypalHandler.ts` but was never wired up — it now is.
- **Google OAuth had no CSRF state** — `generateAuthUrl()` issued no `state`, and the callback didn't validate one, leaving the login flow open to CSRF/account-linking attacks. Added a new `/api/auth/google/login` endpoint that mints a random state into a short-lived httpOnly cookie and validates it on callback with a constant-time comparison. The client now redirects through this endpoint instead of building the Google auth URL (and exposing the client ID) itself.
- **`OFFLINE_MODE=1` bypassed authentication entirely**, returning a hardcoded admin session for any request — now gated to `NODE_ENV=development` so a leaked env var elsewhere can't grant admin access.
- **`SecretsManager` fell back to a hardcoded master key** whenever `INTEGRATIONS_MASTER_KEY` was unset in any non-production environment (including staging) — now restricted to `NODE_ENV=development` only.

## ⚠️ Separate from this PR — secrets need rotation

The audit also found **real credentials committed to git** (independent of any code change here):
- `SECURITY_INCIDENT_SUMMARY.md` and several other `.md` docs contain literal values for `GOOGLE_CLIENT_SECRET`, the database password, `TWITCH_CLIENT_SECRET`, `TICKETMASTER_API_KEY`, `JWT_SECRET`, and a Google/YouTube API key.
- `.env.dev` / `.env.prod` are tracked in git and contain Vercel `VERCEL_OIDC_TOKEN` JWTs.

These need to be **rotated** and scrubbed from git history (BFG/filter-repo) — that's an account/infrastructure action outside the scope of a code change, and I've flagged it to the repo owner directly.

## Test plan

- [x] `npx tsc --noEmit` — confirmed this PR introduces **zero new type errors** (diffed against the same run on `main`; the 1900+ pre-existing errors in `server/routers.ts`/`vite.config.ts`/`paypalHandler.ts` are unchanged)
- [x] `npx vitest run` — same pre-existing failures as `main` (smoke tests require a live server on `127.0.0.1:3000`, unrelated to this change)
- [ ] Manually verify the Google OAuth login flow end-to-end in an environment with `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` configured
- [ ] Configure `PAYPAL_WEBHOOK_ID` and replay a real PayPal webhook to confirm signature verification passes for genuine events
- [ ] Confirm `/api/admin/setup` still works for a fresh database (first admin) and returns 403 thereafter


---
_Generated by [Claude Code](https://claude.ai/code/session_01Abbqeea7wjvoWSUnST58fG)_