### PR TITLE
ci: add explicit Vercel production deploy workflow for main

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -1,0 +1,56 @@
+name: Deploy Frontend to Vercel
+
+# The Vercel git integration stopped auto-deploying pushes to `main`, so the
+# production site stayed pinned to a stale build. This workflow makes the
+# deploy explicit and repeatable: every push to `main` (or a manual run)
+# builds the project with the committed vercel.json and promotes it to
+# production. Requires a `VERCEL_TOKEN` repository secret.
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+# Avoid overlapping production deploys racing each other.
+concurrency:
+  group: vercel-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: team_pkZKY3cOOTBCBUAZ702slPhi
+      VERCEL_PROJECT_ID: prj_KYpQLW6E09bqxHQVIvKel197fXEW
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.4.1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install Vercel CLI
+        run: pnpm add -g vercel@latest
+
+      - name: Pull Vercel project settings
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build (respects vercel.json outputDirectory)
+        run: vercel build --prod --token="$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to production
+        run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Why

`djdannyhecticb.com` was serving the **raw esbuild server bundle** (`dist/index.mjs` source) as its homepage. The root cause — Vercel's Vite preset defaulting `outputDirectory` to `dist/` instead of `dist/public/` — was fixed by the `vercel.json` added in #36.

But while verifying, I found a second problem: **Vercel's git integration has stopped auto-deploying `main`.** The most recent deployment of any kind predates several merged PRs (#35's merge to `main` never produced a production deploy, and neither did #36's). Production is pinned to a stale June-1 build, so the `vercel.json` fix can't reach the live site on its own.

## What this does

Adds `.github/workflows/deploy-vercel.yml` — on every push to `main` (or manual `workflow_dispatch`), it builds with the Vercel CLI (respecting the committed `vercel.json`) and promotes to production. This makes deploys explicit and repeatable instead of depending on the silent/disconnected git integration.

## ⚠️ One manual step required

Add a **`VERCEL_TOKEN`** repository secret (Settings → Secrets and variables → Actions). Create the token at https://vercel.com/account/tokens.

- Org ID (`team_pkZKY3cOOTBCBUAZ702slPhi`) and Project ID (`prj_KYpQLW6E09bqxHQVIvKel197fXEW`) are non-sensitive and inlined in the workflow.
- **Merging this PR is itself a push to `main`, so it triggers the first deploy** — which picks up the `vercel.json` `outputDirectory` fix and restores the site. (If you'd rather not wait for a merge, you can also just hit "Redeploy" on the latest `main` commit in the Vercel dashboard.)

## Scope note

Per discussion, this keeps Vercel as **frontend-only** for now. `/api/*` still 404s on Vercel (the Express backend isn't deployed there) — that's a separate, deferred decision.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abbqeea7wjvoWSUnST58fG)_