### PR TITLE
ci: fix pnpm setup version conflict in Vercel deploy workflow

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -27,9 +27,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
+        # Version is read from package.json's "packageManager" field. Do not also
+        # set a "version" input here — pnpm/action-setup errors on a double spec.
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.4.1
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Why

The first run of the new `deploy-vercel.yml` workflow (from #37) failed immediately at the **Setup pnpm** step:

```
Error: Multiple versions of pnpm specified:
  - version 10.4.1 in the GitHub Action config with the key "version"
  - version pnpm@10.4.1+sha512... in the package.json with the key "packageManager"
```

`pnpm/action-setup@v4` refuses to run when the version is specified both ways.

## Fix

Remove the `version:` input from the action and let it read the canonical version from `package.json`'s `packageManager` field.

Merging this re-triggers the deploy workflow. The next failure point (if any) will be the `Pull Vercel project settings` step, which needs the `VERCEL_TOKEN` secret — so this also serves to confirm whether that secret is configured.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abbqeea7wjvoWSUnST58fG)_