### PR TITLE
fix: replace process.env with import.meta.env in client, fix server URL fallbacks

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -81,7 +81,7 @@ const trpcClient = trpc.createClient({
 // Listen for service worker updates
 if (typeof window !== "undefined") {
   window.addEventListener("sw-update-available", () => {
-    if (process.env.NODE_ENV === "development") {
+    if (import.meta.env.DEV) {
       console.log("Service Worker update available");
     }
   });

--- a/client/src/utils/helpers/notifications.ts
+++ b/client/src/utils/helpers/notifications.ts
@@ -49,7 +49,7 @@ export async function subscribeToPushNotifications(): Promise<PushSubscription |
     const registration = await navigator.serviceWorker.ready;
     const subscription = await registration.pushManager.subscribe({
       userVisibleOnly: true,
-      applicationServerKey: process.env.VITE_VAPID_PUBLIC_KEY,
+      applicationServerKey: import.meta.env.VITE_VAPID_PUBLIC_KEY,
     });
 
     return subscription;

--- a/server/_core/paypalService.ts
+++ b/server/_core/paypalService.ts
@@ -113,8 +113,8 @@ export async function createPayPalOrder(params: {
       brand_name: "DJ Danny Hectic B",
       locale: "en-GB",
       user_action: "PAY_NOW",
-      return_url: `${process.env.VITE_API_URL || "http://localhost:3000"}/checkout/success`,
-      cancel_url: `${process.env.VITE_API_URL || "http://localhost:3000"}/checkout`,
+      return_url: `${process.env.BASE_URL || "https://djdannyhecticb.com"}/checkout/success`,
+      cancel_url: `${process.env.BASE_URL || "https://djdannyhecticb.com"}/checkout`,
     },
   };
 

--- a/server/domains/auth/googleAuth.ts
+++ b/server/domains/auth/googleAuth.ts
@@ -29,7 +29,7 @@ if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET) {
 const oauth2Client = new OAuth2Client(
   GOOGLE_CLIENT_ID,
   GOOGLE_CLIENT_SECRET,
-  `${process.env.BASE_URL || "http://localhost:3000"}/api/auth/google/callback`
+  `${process.env.BASE_URL || "https://djdannyhecticb.com"}/api/auth/google/callback`
 );
 
 export function registerGoogleAuthRoutes(app: Express) {


### PR DESCRIPTION
Four env var bugs that caused silent failures in production:

- **`client/src/main.tsx`**: `process.env.NODE_ENV` → `import.meta.env.DEV` — `process.env` is undefined in Vite browser builds so dev logging was always suppressed
- **`client/src/utils/helpers/notifications.ts`**: `process.env.VITE_VAPID_PUBLIC_KEY` → `import.meta.env.VITE_VAPID_PUBLIC_KEY` — push notification subscriptions were always failing because the VAPID key was always `undefined`
- **`server/domains/auth/googleAuth.ts`**: localhost:3000 fallback → production domain for Google OAuth redirect URI
- **`server/_core/paypalService.ts`**: `VITE_API_URL` (client-only env prefix, undefined on server) → `BASE_URL` for PayPal return/cancel URLs; also fixes localhost fallback

https://claude.ai/code/session_01Abbqeea7wjvoWSUnST58fG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abbqeea7wjvoWSUnST58fG)_